### PR TITLE
fix the badges2 fix

### DIFF
--- a/mapfixes_bhop.txt
+++ b/mapfixes_bhop.txt
@@ -37,7 +37,7 @@ add map data:
 tested, pending upload & add map data:
 
 submitted fixes need add map data:
-10049775129 - Badges 2 - Spawns in many places were completely broken and bugged, every spawn is fixed, also fixed booster bugs.
+12298088598 - Badges 2 - Spawns in many places were completely broken and bugged, every spawn is fixed, also fixed booster bugs. Also fixed multiple impossibly (or unreasonably) small gaps and the KZ triggerskip.
 
 rejected fixes, additional fix notes:
 11750977271 - Alley - End compatible with new physics + spawn fixed - There's a weird part in the middle of the start zone that you bump into


### PR DESCRIPTION
Note that, while the ID of where I have the model stored permenantly is `12298088598`, I'm actually using an old model slot I've got, `2992408942`, to load it in maptest since maptest bot is down and I can't have it take the new model. While `2992408942` is the fix *right now*, I may replace it with another temporary model at a later date, so if `12298088598` could get taken by the maptest bot somehow that'd be helpful.