### PR TITLE
Remove spawnlocation objects causing forcefields

### DIFF
--- a/mapfixes_bhop.txt
+++ b/mapfixes_bhop.txt
@@ -31,6 +31,8 @@ tested, pending upload:
 
 submitted fixes (no wipe):
 10060990749 - Synced V2 - Fixed RNG jump next to ladder (moved rock blocks up 0.2 studs)
+12945479548 - Bounce Pad - Removed spawnlocation object leading to annoying forcefields
+12945532940 - Golf Yourself - Removed spawnlocation object leading to annoying forcefields
 
 add map data:
 10049651200 - Tech (COMPETING FIX IN HUB)- Fixed every possible skip in tech.

--- a/mapfixes_surf.txt
+++ b/mapfixes_surf.txt
@@ -12,6 +12,7 @@ submitted fixes (wipe times):
 tested, pending upload:
 
 submitted fixes (no wipe):
+12945558885 - gg no re - Removed spawnlocation object leading to annoying forcefields
 
 add map data:
 10076615800 - 30 Minutes (removed) - Removed the ability to get on top of the telehop.


### PR DESCRIPTION
Note: The maptest bot appears to be revolting against me and won't take the golf yourself model (`12945532940`) no matter how much I ask it to, but the other 2 submitted fine.