### PR TITLE
+Lavender lighting fix

### DIFF
--- a/mapfixes_bhop.txt
+++ b/mapfixes_bhop.txt
@@ -34,6 +34,7 @@ tested, pending upload:
 submitted fixes (no wipe):
 10060990749 - Synced V2 (COPYLOCKED) - Fixed RNG jump next to ladder (moved rock blocks up 0.2 studs)
 12945532940 - Golf Yourself - Removed spawnlocation object leading to annoying forcefields
+13553729461 - Lavender - Fixes the lighting for future lighting (The lights were on about 10k brightness). Note that the core physics bug behind the map not working still exists (See PR for more detail)
 
 add map data:
 


### PR DESCRIPTION
Note that the core physics bug behind this map not working is still present (Colliding with a sphere and another object at the same time - even if the sphere is non-collide - will cause an error in Trey-MinimumDifference)

This fix needs to happen regardless, since the current version of the map may actually make you blind, but this won't fix the physics bug. We could technically quick-patch the bug and remove the meshes from the bushes (mesh-less fix available in `13553743491`), but I think it would be better to have the core issue fixed instead of a bandaid fix.