### PR TITLE
Update submissions_surf.txt

### DIFF
--- a/submissions_surf.txt
+++ b/submissions_surf.txt
@@ -24,6 +24,7 @@ not in inventory:
 10908602837
 10908669666
 11183538845
+13851697452 (the map was initially rejected due to the use of another map makers logo, the creator has since removed the logo and the map was accepted)
 
 misnamed model:
 11168457674


### PR DESCRIPTION
added map to submissions.

the creator had a logo in the map from a different creator that had nothing to do with the map, it was accepted but later rejected because of the logo.

The creator has removed the logo and anything else related to the creator, the map has since been accepted since the logo is no longer there, just adding it to the submissions now