### PR TITLE
dunes bonus fix

### DIFF
--- a/mapfixes_surf.txt
+++ b/mapfixes_surf.txt
@@ -13,6 +13,7 @@ submitted fixes (wipe times):
 tested, pending upload:
 
 submitted fixes (no wipe):
+12804314773 - Dunes - fixed bonus startzone being too low. world position has not changed so hopefully no wipe needed
 17722224669 - Aztec -  moved closer to origin and zoned bonus
 
 add map data:


### PR DESCRIPTION
fixed bonus startzone being too low and spawning player underneath the platform